### PR TITLE
fix: Handle empty decoding values for Status

### DIFF
--- a/Sources/Health/Protocols.swift
+++ b/Sources/Health/Protocols.swift
@@ -122,7 +122,7 @@ public struct Status: Equatable {
     self.state = state
     self.details = details
     if let _ = Status.dateFormatter.date(from: timestamp) {
-      self.timestamp = timestamp  
+      self.timestamp = timestamp
     } else {
       self.timestamp = Status.dateFormatter.string(from: Date())
       Log.warning("Provided timestamp value '\(timestamp)' is not valid; using current time value instead.")
@@ -162,15 +162,26 @@ extension Status: Encodable {
 extension Status: Decodable {
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
-    let status = try values.decode(String.self, forKey: .status)
-    
+    var status = try values.decode(String.self, forKey: .status)
+
+    if status == "" {
+      status = "DOWN"
+    }
+
     guard let state = State(rawValue: status) else {
       throw InvalidDataError.deserialization("'\(status)' is not a valid status value.")
     }
-    
+
     let details = try values.decode([String].self, forKey: .details)
-    let timestamp = try values.decode(String.self, forKey: .timestamp)
-    
+    var timestamp = try values.decode(String.self, forKey: .timestamp)
+
+    if timestamp == "" {
+      var dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+      let date = Date()
+      timestamp = dateFormatter.string(from: date)
+    }
+
     guard let _ = Status.dateFormatter.date(from: timestamp) else {
        throw InvalidDataError.deserialization("'\(timestamp)' is not a valid timestamp value.")
     }


### PR DESCRIPTION
When the TypeDecoder decodes the Status type it returns dummy values. Within the decode method of Status, if verifies that the values returned by the decoder are valid and if they are not it throws. This means that the TypeDecoder does not complete. In order to solve this issue, if the value given by the TypeDecoder is a blank string then we create a valid one.